### PR TITLE
Added BCUninstaller (Bulk Crap Uninstaller)

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -84,6 +84,13 @@
       },
       "version": "latest"
     },
+    "bcuninstaller": {
+      "installer": {
+        "kind": "innosetup",
+        "x86": "https://github.com/Klocman/Bulk-Crap-Uninstaller/releases/download/v{{.version}}/BCUninstaller_{{.version}}_setup.exe"
+      },
+      "version": "3.13"
+	},
     "brackets": {
       "installer": {
         "kind": "msi",


### PR DESCRIPTION
Bulk Crap Uninstaller is an uninstall program where you can uninstall multiple programs at a time. This program features some nice features such as killing the program before you install it, removing traces after an uninstall and more.

I've tested it and it downloaded and installed successfully in silent mode.