### PR TITLE
fix(config): make visual-studio-code actually silent

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -1609,9 +1609,16 @@
     },
     "visual-studio-code": {
       "installer": {
-        "kind": "innosetup",
+        "kind": "custom",
         "options": {
-          "extension": ".exe"
+          "extension": ".exe",
+          "arguments": [
+            "{{.installer}}",
+            "/norestart",
+            "/sp-",
+            "/verysilent",
+            "/mergetasks=!runcode"
+          ]
         },
         "x86": "https://go.microsoft.com/fwlink/?LinkID=623230",
         "x86_64": "https://go.microsoft.com/fwlink/?Linkid=852157"


### PR DESCRIPTION
even if visual-studio-code is using innosetup, it automatically starts after the installation. i changed the config according to https://stackoverflow.com/questions/42582230/how-to-install-visual-studio-code-silently-without-auto-open-when-installation while still using the standard innosetup flags.