### PR TITLE
feat(config): remove pyqt

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -1138,14 +1138,6 @@
       },
       "version": "2017.3.3"
     },
-    "pyqt": {
-      "installer": {
-        "kind": "nsis",
-        "x86": "http://downloads.sourceforge.net/project/pyqt/PyQt4/PyQt-{{.version}}/PyQt4-{{.version}}-gpl-Py2.7-Qt4.8.7-x32.exe",
-        "x86_64": "http://downloads.sourceforge.net/project/pyqt/PyQt4/PyQt-{{.version}}/PyQt4-{{.version}}-gpl-Py2.7-Qt4.8.7-x64.exe"
-      },
-      "version": "4.11.4"
-    },
     "python2": {
       "installer": {
         "kind": "msi",


### PR DESCRIPTION
starting from [pyqt 4.11.4](https://sourceforge.net/projects/pyqt/files/PyQt4/PyQt-4.11.4/) and [pyqt 5.6](https://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.6/), pyqt isnt available as executables anymore, and [the installation via pip is recommended](http://pyqt.sourceforge.net/Docs/PyQt5/installation.html).