### PR TITLE
Added bcc (a BCS, ACS, and ACS95 compiler used by Doom ports).

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -130,6 +130,20 @@
       },
       "version": "latest"
     },
+	"bcc": {
+      "installer": {
+        "kind": "zip",
+        "options": {
+          "destination": "{{.PROGRAMFILES}}\\bcc",
+          "shims": [
+            "{{.PROGRAMFILES}}\\bcc\\bcc.exe"
+          ]
+        },
+        "x86": "https://github.com/wormt/bcc/releases/download/{{.version}}/bcc-{{.version}}-32bit.zip",
+        "x86_64": "https://github.com/wormt/bcc/releases/download/{{.version}}/bcc-{{.version}}-64bit.zip"
+      },
+      "version": "0.8.0"
+    },
     "bcuninstaller": {
       "installer": {
         "kind": "innosetup",


### PR DESCRIPTION
There's just 1 problem: when zip file gets extracted, its sub-folders don't get created under Program Files as supposed to. I'm not exactly sure why this is happening. Posted it here anyways.