### PR TITLE
add version numbers to java

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -994,7 +994,7 @@
       },
       "version": "latest"
     },
-    "jdk": {
+    "jdk8": {
       "installer": {
         "kind": "custom",
         "options": {
@@ -1028,7 +1028,7 @@
       },
       "version": "latest"
     },
-    "jre": {
+    "jre8": {
       "installer": {
         "kind": "custom",
         "options": {


### PR DESCRIPTION
in order to provide different java versions, i added version numbers to the java entries in this PR. when the MSI files for the "AdoptOpenJDK" binarys are getting released, i would provide entries for the respective versions 8 and 11 to just-install ("openjdk-jdk11" for example).

https://adoptopenjdk.net/
https://github.com/AdoptOpenJDK/openjdk-build/issues/459
https://github.com/AdoptOpenJDK/openjdk-installer