### PR TITLE
Fix foobar2000

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -733,7 +733,7 @@
     "foobar2000": {
       "installer": {
         "kind": "nsis",
-        "x86": "https://www.foobar2000.org/files/2c3b9ba9af4ddfa2b720112a7c498c5a/foobar2000_v1.4.3.exe"
+        "x86": "https://github.com/tlm-2501/ji/raw/master/foobar2000_v1.4.3.exe"
       },
       "version": "1.4.3"
     },


### PR DESCRIPTION
Apparently the foobar2000 website generates temporary download links. Whoops. I had to mirror the installer to make this package usable.