### PR TITLE
Add mpv media player

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -1274,7 +1274,7 @@
         "options": {
           "arguments": [
             "powershell",
-            "expand-archive {{.installer}} -DestinationPath '{{.PROGRAMFILES}}\\mpv'; cd '{{.PROGRAMFILES}}\\mpv'; cmd /c start cmd /k updater.bat"
+            "Add-Type -as System.IO.Compression.FileSystem; [System.IO.Compression.ZipFile]::ExtractToDirectory('{{.installer}}', '{{.PROGRAMFILES}}\\mpv'); cd '{{.PROGRAMFILES}}\\mpv'; cmd /c start cmd /k updater.bat"
           ]
         }
       }

--- a/just-install.json
+++ b/just-install.json
@@ -1266,6 +1266,19 @@
       },
       "version": "1.7.13"
     },
+    "mpv": {
+      "version": "latest",
+      "installer": {
+        "x86": "https://downloads.sourceforge.net/project/mpv-player-windows/bootstrapper.zip",
+        "kind": "custom",
+        "options": {
+          "arguments": [
+            "powershell",
+            "expand-archive {{.installer}} -DestinationPath '{{.PROGRAMFILES}}\\mpv'; cd '{{.PROGRAMFILES}}\\mpv'; cmd /c start cmd /k updater.bat"
+          ]
+        }
+      }
+    },
     "mullvad": {
       "installer": {
         "interactive": true,


### PR DESCRIPTION
I understand that the "arguments" field is something of a mess. So I shall explain:
- The updater has to be ran from the folder where MPV needs to be installed, thus I can't just run it "as-is".
- The updater is "interactive" in a way. It doesn't actually *require* user-input and all the defaults are fine, it will just accept them after the time out. However, from testing, it seemed to refuse to run without its own window. This is the reason for the `cmd /c start cmd /k` magic, which opens the window for it.