### PR TITLE
Fix mednafen version

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -1241,7 +1241,7 @@
         "x86": "https://mednafen.github.io/releases/files/mednafen-{{.version}}-win32.zip",
         "x86_64": "https://mednafen.github.io/releases/files/mednafen-{{.version}}-win64.zip"
       },
-      "version": "1.22.1"
+      "version": "latest"
     },
     "mercurial": {
       "installer": {


### PR DESCRIPTION
I found out that they have a symlink to the "latest" version on their server, conveniently labelled just that. What do you know, it's nowhere on the actual website. The jiup-go rule mentioned in #123 should no longer be needed after this.