### PR TITLE
Add Code::Blocks 17.12

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -313,6 +313,26 @@
       },
       "version": "3.15.1"
     },
+    "codeblocks": {
+      "installer": {
+        "kind": "nsis",
+        "options": {
+          "extension": ".exe"
+        },
+        "x86": "https://sourceforge.net/projects/codeblocks/files/Binaries/{{.version}}/Windows/codeblocks-{{.version}}-setup.exe/download"
+      },
+      "version": "17.12"
+    },
+    "codeblocks-mingw": {
+      "installer": {
+        "kind": "nsis",
+        "options": {
+          "extension": ".exe"
+        },
+        "x86": "https://sourceforge.net/projects/codeblocks/files/Binaries/{{.version}}/Windows/codeblocks-{{.version}}mingw-setup.exe/download"
+      },
+      "version": "17.12"
+    },
     "colemak": {
       "installer": {
         "kind": "as-is",


### PR DESCRIPTION
Code::Blocks is one of the programs required for the final exams in Poland: https://cke.gov.pl/images/_KOMUNIKATY/20180820%20EM%20Komunikat%20o%20egzaminie%20z%20informatyki.pdf

It is very important for us (as a school) to have is in just-install.