### PR TITLE
Add Audacity 2.3.1

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -106,6 +106,13 @@
       },
       "version": "latest"
     },
+    "audacity": {
+      "installer": {
+        "kind": "eve",
+        "x86": "https://www.fosshub.com/Audacity.html/audacity-win-{{.version}}.exe"
+      },
+      "version": "2.3.1"
+    },
     "autohotkey": {
       "installer": {
         "kind": "nsis",


### PR DESCRIPTION
Note: fossshub is where audacity hosts their files per https://www.audacityteam.org/download/windows/  
  
"Left-click the Audacity installer link below to go to the Fosshub download page (where our downloads are hosted)."