### PR TITLE
Use custom arguments for dbeaver installer

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -435,7 +435,14 @@
     },
     "dbeaver": {
       "installer": {
-        "kind": "nsis",
+        "kind": "custom",
+        "options": {
+          "arguments": [
+            "{{.installer}}",
+            "/allusers",
+            "/S"
+          ]
+        },
         "x86_64": "https://github.com/dbeaver/dbeaver/releases/download/6.2.1/dbeaver-ce-6.2.1-x86_64-setup.exe"
       },
       "version": "6.2.1"


### PR DESCRIPTION
The dbeaver installer appears to have changed. It no longer likes the `/NCRC` flag that's part of the NSIS installer args.

This PR uses custom arguments to run dbeaver installer.

```
PS C:\Windows\system32> just-install dbeaver
2019/10/04 09:24:33 Updating registry from: https://just-install.github.io/registry/just-install-v4.json
 79.91 KiB / ? [-------------------------------------=------------------------------------------------] 15.64 MiB/s 0s
2019/10/04 09:24:33 x86_64 - https://github.com/dbeaver/dbeaver/releases/download/6.2.1/dbeaver-ce-6.2.1-x86_64-setup.exe
 48.58 MiB / 48.58 MiB [=======================================================================] 100.00% 24.36 MiB/s 1s
2019/10/04 09:24:35 Running C:\Users\Nithin\AppData\Local\Temp\just-install\B40E6373.exe /S /NCRC
2019/10/04 09:24:35 exit status 666660
```