### PR TITLE
Update jdk to latest version

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -1159,10 +1159,9 @@
             "/s"
           ]
         },
-        "x86": "http://download.oracle.com/otn-pub/java/jdk/8u221-b11/230deb18db3e4014bb8e3e8324f81b43/jdk-8u221-windows-i586.exe",
-        "x86_64": "http://download.oracle.com/otn-pub/java/jdk/8u221-b11/230deb18db3e4014bb8e3e8324f81b43/jdk-8u221-windows-x64.exe"
+        "x86_64": "https://download.oracle.com/otn-pub/java/jdk/13+33/5b8a42f3905b406298b72d750b6919f6/jdk-13_windows-x64_bin.exe"
       },
-      "version": "8u221-b11"
+      "version": "13"
     },
     "jetbrains-toolbox": {
       "installer": {


### PR DESCRIPTION
JDK 8 now requires an account to be downloaded.
I am not sure about the `x86_64` property, but Oracle only provides x64 version since at least JDK 11.
Should I just set the `x86` property?