### PR TITLE
Update blender to 2.81 (drop 32bit support)

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -210,10 +210,9 @@
     "blender": {
       "installer": {
         "kind": "msi",
-        "x86": "https://download.blender.org/release/Blender2.80/blender-2.80-windows32.msi",
-        "x86_64": "https://download.blender.org/release/Blender2.80/blender-2.80-windows64.msi"
+        "x86_64": "https://download.blender.org/release/Blender2.81/blender-2.81-windows64.msi"
       },
-      "version": "2.80"
+      "version": "2.81"
     },
     "brackets": {
       "installer": {


### PR DESCRIPTION
Per https://blenderartists.org/t/32-bit-programming-is-finally-dead-blender-2-81-dev-now-64-bit-only/1172927