### PR TITLE
Add Rocket.Chat Electron Installer EXE

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -2056,6 +2056,22 @@
       },
       "version": "1.8.1"
     },
+	  "rocketchat": {
+      "installer": {
+        "kind": "custom",
+        "options": {
+          "arguments": [
+            "msiexec.exe",
+            "/S",
+            "/allusers",
+			      "/disableAutoUpdates",
+            "{{.installer}}",
+          ]
+        },
+        "x86": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/{{.version}}/rocketchat-setup-{{.version}}.exe"
+      },
+	  "version": "2.17.1"
+    },
     "ruby": {
       "installer": {
         "kind": "innosetup",

--- a/just-install.json
+++ b/just-install.json
@@ -2056,18 +2056,17 @@
       },
       "version": "1.8.1"
     },
-	  "rocketchat": {
+    "rocketchat": {
       "installer": {
         "kind": "custom",
         "options": {
           "arguments": [
-            "msiexec.exe",
+            "{{.installer}}",
             "/S",
             "/allusers",
-			      "/disableAutoUpdates",
-            "{{.installer}}",
-          ]
-        },
+            "/disableAutoUpdates"
+           ]
+       },
         "x86": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/{{.version}}/rocketchat-setup-{{.version}}.exe"
       },
 	  "version": "2.17.1"

--- a/just-install.json
+++ b/just-install.json
@@ -2065,11 +2065,11 @@
             "/S",
             "/allusers",
             "/disableAutoUpdates"
-           ]
-       },
+          ]
+        },
         "x86": "https://github.com/RocketChat/Rocket.Chat.Electron/releases/download/{{.version}}/rocketchat-setup-{{.version}}.exe"
       },
-	  "version": "2.17.1"
+      "version": "2.17.1"
     },
     "ruby": {
       "installer": {

--- a/just-install.json
+++ b/just-install.json
@@ -449,9 +449,9 @@
     "deluge": {
       "installer": {
         "kind": "nsis",
-        "x86": "http://download.deluge-torrent.org/windows/deluge-2.0.3-win32-py2.7.exe"
+        "x86": "http://download.deluge-torrent.org/windows/deluge-1.3.15-win32-py2.7.exe"
       },
-      "version": "2.0.3"
+      "version": "1.3.15"
     },
     "dependency-walker": {
       "installer": {
@@ -836,16 +836,16 @@
     "flash-player": {
       "installer": {
         "kind": "msi",
-        "x86": "https://fpdownload.macromedia.com/get/flashplayer/pdc/32.0.0.293/install_flash_player_32_plugin.msi"
+        "x86": "https://sourceforge.net/projects/adobe-flash-msi-installers/files/v32.0.0.192/install_flash_player_32_plugin.msi/download"
       },
-      "version": "32.0.0.293"
+      "version": "32.0.0.192"
     },
     "flash-player-ie": {
       "installer": {
         "kind": "msi",
-        "x86": "https://fpdownload.macromedia.com/get/flashplayer/pdc/32.0.0.293/install_flash_player_32_active_x.msi"
+        "x86": "https://sourceforge.net/projects/adobe-flash-msi-installers/files/v32.0.0.192/install_flash_player_32_active_x.msi/download"
       },
-      "version": "32.0.0.293"
+      "version": "32.0.0.192"
     },
     "flux": {
       "installer": {
@@ -857,9 +857,9 @@
     "foobar2000": {
       "installer": {
         "kind": "nsis",
-        "x86": "https://github.com/tlm-2501/ji/raw/master/foobar2000_v1.4.3.exe"
+        "x86": "https://www.foobar2000.org/files/1d6fa3c272fbd7766544615415cc2ba5/foobar2000_v1.5.exe"
       },
-      "version": "1.4.3"
+      "version": "1.5"
     },
     "foxitreader": {
       "installer": {
@@ -878,13 +878,6 @@
         "x86_64": "https://github.com/FreeCAD/FreeCAD/releases/download/0.18.3/FreeCAD-0.18.16131.3129ae4-WIN-x64-installer.exe"
       },
       "version": "0.18.3"
-    },
-    "freefilesync": {
-      "installer": {
-        "kind": "as-is",
-        "x86": "https://www.freefilesync.org/download/FreeFileSync_10.18_Windows_Setup.exe"
-      },
-      "version": "10.18."
     },
     "freeplane": {
       "installer": {
@@ -1292,7 +1285,7 @@
     "lockhunter": {
       "installer": {
         "kind": "innosetup",
-        "x86": "http://lockhunter.com/exe/lockhuntersetup_3-3-4.exe"
+        "x86": "https://lockhunter.com/assets/exe/lockhuntersetup_3-3-4.exe"
       },
       "version": "3.3.4"
     },
@@ -1605,7 +1598,7 @@
     "openvpn": {
       "installer": {
         "kind": "nsis",
-        "x86": "https://build.openvpn.net/downloads/releases/latest/openvpn-install-latest-stable.exe"
+        "x86": "https://build.openvpn.net/downloads/releases/latest/openvpn-install-latest-stable-win10.exe"
       },
       "version": "latest"
     },
@@ -2164,10 +2157,10 @@
         "options": {
           "extension": ".exe"
         },
-        "x86": "https://sourceforge.net/projects/smplayer/files/SMPlayer/19.10.2/smplayer-19.10.2-win32.exe/download",
-        "x86_64": "https://sourceforge.net/projects/smplayer/files/SMPlayer/19.10.2/smplayer-19.10.2-x64.exe/download"
+        "x86": "https://sourceforge.net/projects/smplayer/files/SMPlayer/19.10.0/smplayer-19.10.0-win32.exe/download",
+        "x86_64": "https://sourceforge.net/projects/smplayer/files/SMPlayer/19.10.0/smplayer-19.10.0-x64.exe/download"
       },
-      "version": "19.10.2"
+      "version": "19.10.0"
     },
     "sourcetree": {
       "installer": {
@@ -2694,7 +2687,7 @@
     "ynab": {
       "installer": {
         "kind": "innosetup",
-        "x86": "https://downloadpull-youneedabudgetco.netdna-ssl.com/ynab4/liveCaptive/Win/YNAB%204_4.3.857_Setup.exe"
+        "x86": "https://www-assets.youneedabudget.com/ynab4/YNAB+4_4.3.857_Setup.exe"
       },
       "version": "4.3.857"
     },


### PR DESCRIPTION
I was able to add Rocket.Chat Electron Installer EXE with next flagues:
- "/S" - silent (unattended) installation,
- "/allusers" for All Users (with Administrative Privilages),
- "/disableAutoUpdates" without Updates Notifications

This kind of installation is unable to create autostart shortcut for Windows, so if you need one, you have to create startup PS script for users:

```
Set-Variable -Name "autostart" -Value "$Env:USERPROFILE\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup\Rocket.Chat.lnk"

if (!(Test-Path $autostart)) {
	copy "$Env:PUBLIC\Desktop\Rocket.Chat.lnk" $autostart
	cd "$Env:ProgramFiles\Rocket.Chat"
	start Rocket.Chat.exe
}