### PR TITLE
Add python3-minimal

### DIFF
--- a/just-install.json
+++ b/just-install.json
@@ -1820,6 +1820,22 @@
       },
       "version": "3.8.1"
     },
+    "python3-minimal": {
+      "installer": {
+        "kind": "custom",
+        "options": {
+          "arguments": [
+            "{{.installer}}",
+            "/quiet",
+            "InstallAllUsers=1",
+            "Include_tcltk=0"
+          ]
+        },
+        "x86": "https://www.python.org/ftp/python/{{.version}}/python-{{.version}}.exe",
+        "x86_64": "https://www.python.org/ftp/python/{{.version}}/python-{{.version}}-amd64.exe"
+      },
+      "version": "3.8.1"
+    },
     "qbittorrent": {
       "installer": {
         "kind": "nsis",


### PR DESCRIPTION
Minimal install of Python3. No tk and no IDLE. Ideal for an environment where you just need to run your Python3 scripts.