### PR TITLE
Remove okular

### DIFF
--- a/just-install-v4.json
+++ b/just-install-v4.json
@@ -1557,13 +1557,6 @@
       },
       "version": "5.2.0"
     },
-    "okular": {
-      "installer": {
-        "kind": "nsis",
-        "x86_64": "https://binary-factory.kde.org/view/Windows%2064-bit/job/Okular_Release_win64/lastSuccessfulBuild/artifact/okular-{{.version}}-windows-msvc2019_64-cl.exe"
-      },
-      "version": "20.04.2-313"
-    },
     "onlyoffice-desktopeditors": {
       "installer": {
         "kind": "innosetup",


### PR DESCRIPTION
Doesn't have a stable download URL

I wanted to make an updater rule when I realized that `313` the the artifact name is the build id. Next build artifact will have a different id in the name and the link will stop working. We can't point to artifacts of a build because everyday there is a new build and they only keep last 10 builds so the link would work for 10 days.

I'm sorry for that. I should have checked that when adding the rule. I will open an issue at KDE and hope that they can provide stable download URLs.