### PR TITLE
Fix bleachbit installer

### DIFF
--- a/just-install-v4.json
+++ b/just-install-v4.json
@@ -265,7 +265,14 @@
     },
     "bleachbit": {
       "installer": {
-        "kind": "nsis",
+        "kind": "custom",
+        "options": {
+          "arguments": [
+            "{{.installer}}",
+            "/allusers",
+            "/S"
+          ]
+        },
         "x86": "https://download.bleachbit.org/BleachBit-4.0.0-setup.exe"
       },
       "version": "4.0.0"


### PR DESCRIPTION
The installer requires either /allusers or /currentusers flag to be
present