### PR TITLE
Fix Double Commander x86 setup

### DIFF
--- a/just-install-v4.json
+++ b/just-install-v4.json
@@ -635,12 +635,12 @@
     },
     "doublecmd": {
       "installer": {
-        "kind": "msi",
+        "kind": "innosetup",
         "options": {
           "extension": ".exe"
         },
-        "x86": "https://sourceforge.net/projects/doublecmd/files/DC%20for%20Windows%2032%20bit/Double%20Commander%200.9.9%20beta/doublecmd-0.9.9.i386-win32.msi/download",
-        "x86_64": "https://sourceforge.net/projects/doublecmd/files/DC%20for%20Windows%2064%20bit/Double%20Commander%200.9.9%20beta/doublecmd-0.9.9.x86_64-win64.msi/download"
+        "x86": "https://sourceforge.net/projects/doublecmd/files/DC%20for%20Windows%2032%20bit/Double%20Commander%200.9.9%20beta/doublecmd-0.9.9.i386-win32.exe/download",
+        "x86_64": "https://sourceforge.net/projects/doublecmd/files/DC%20for%20Windows%2064%20bit/Double%20Commander%200.9.9%20beta/doublecmd-0.9.9.x86_64-win64.exe/download"
       },
       "version": "0.9.9"
     },


### PR DESCRIPTION
The authors of `doublecmd` also provide an `.exe` installer. Using it instead of the `.msi` fixes the 32-bit installation.