### PR TITLE
Fix Python 2 installation

### DIFF
--- a/just-install-v4.json
+++ b/just-install-v4.json
@@ -1861,8 +1861,15 @@
     },
     "python2": {
       "installer": {
-        "kind": "msi",
+        "kind": "custom",
         "options": {
+          "arguments": [
+            "msiexec.exe",
+            "/q",
+            "/i",
+            "{{.installer}}",
+            "REBOOT=ReallySuppress"
+          ],
           "shims": [
             "{{.SYSTEMDRIVE}}\\Python27\\python.exe",
             "{{.SYSTEMDRIVE}}\\Python27\\pythonw.exe"


### PR DESCRIPTION
If the `ALLUSERS` option is provided to the `.msi` executor, the Python 2 setup fails with exit code `1603`. Removing the `ALLUSERS` option fixes it.