### PR TITLE
Revert "Fix Python 2 installation"

### DIFF
--- a/just-install-v4.json
+++ b/just-install-v4.json
@@ -1861,15 +1861,8 @@
     },
     "python2": {
       "installer": {
-        "kind": "custom",
+        "kind": "msi",
         "options": {
-          "arguments": [
-            "msiexec.exe",
-            "/q",
-            "/i",
-            "{{.installer}}",
-            "REBOOT=ReallySuppress"
-          ],
           "shims": [
             "{{.SYSTEMDRIVE}}\\Python27\\python.exe",
             "{{.SYSTEMDRIVE}}\\Python27\\pythonw.exe"


### PR DESCRIPTION
Reverts just-install/registry#237

The issue only occurs when the Microsoft Visual C++ 2008 redistributable is missing on the system prior to running the Python 2 setup (e.g. on a Windows Sandbox).

This is not something j-i can handle (at least for now) and should be resolved by explicitly installing Visual C++ beforehand.