### PR TITLE
Update Jetbrains IDEs to 2020.3 and switch to standard "nsis" installer

### DIFF
--- a/just-install-v4.json
+++ b/just-install-v4.json
@@ -1168,10 +1168,10 @@
     },
     "intellij-idea-community": {
       "installer": {
-        "kind": "jetbrains-nsis",
-        "x86": "https://download.jetbrains.com/idea/ideaIC-2020.2.4.exe"
+        "kind": "nsis",
+        "x86": "https://download.jetbrains.com/idea/ideaIC-2020.3.exe"
       },
-      "version": "2020.2.4"
+      "version": "2020.3"
     },
     "irfanview": {
       "installer": {
@@ -1828,10 +1828,10 @@
     },
     "pycharm-community": {
       "installer": {
-        "kind": "jetbrains-nsis",
-        "x86": "https://download.jetbrains.com/python/pycharm-community-2020.2.4.exe"
+        "kind": "nsis",
+        "x86": "https://download.jetbrains.com/python/pycharm-community-2020.3.exe"
       },
-      "version": "2020.2.4"
+      "version": "2020.3"
     },
     "python2": {
       "installer": {

--- a/just-install-v4.schema.json
+++ b/just-install-v4.schema.json
@@ -86,7 +86,6 @@
                     "easy_install_26",
                     "easy_install_27",
                     "innosetup",
-                    "jetbrains-nsis",
                     "msi",
                     "nsis",
                     "squirrel",


### PR DESCRIPTION
Also remove the "jetbrains-nsis" installer from the JSON schema since it
should not be required anymore (and will be removed from a future
just-install release).