### PR TITLE
Update uplay -> ubisoft connect

### DIFF
--- a/just-install-v4.json
+++ b/just-install-v4.json
@@ -2210,13 +2210,13 @@
       },
       "version": "3.00"
     },
-    "uplay": {
+    "ubisoft-connect": {
       "installer": {
         "kind": "nsis",
         "options": {
           "extension": ".exe"
         },
-        "x86": "https://ubistatic3-a.akamaihd.net/orbit/launcher_installer/UplayInstaller.exe"
+        "x86": "https://ubistatic3-a.akamaihd.net/orbit/launcher_installer/UbisoftConnectInstaller.exe"
       },
       "version": "latest"
     },


### PR DESCRIPTION
solve #250. Ubisoft has recently phased out Uplay in favor of thier new Ubisoft Connect. This needs to be updated in the registry, which currently still has the old uplay.